### PR TITLE
return each record inside {data}

### DIFF
--- a/airbyte-integrations/connectors/source-kobotoolbox/Dockerfile
+++ b/airbyte-integrations/connectors/source-kobotoolbox/Dockerfile
@@ -31,5 +31,5 @@ COPY source_kobotoolbox ./source_kobotoolbox
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/source-kobotoolbox

--- a/airbyte-integrations/connectors/source-kobotoolbox/Dockerfile
+++ b/airbyte-integrations/connectors/source-kobotoolbox/Dockerfile
@@ -31,5 +31,5 @@ COPY source_kobotoolbox ./source_kobotoolbox
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
-LABEL io.airbyte.name=airbyte/source-kobotoolbox
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=tech4dev/source-kobotoolbox

--- a/airbyte-integrations/connectors/source-kobotoolbox/source_kobotoolbox/source.py
+++ b/airbyte-integrations/connectors/source-kobotoolbox/source_kobotoolbox/source.py
@@ -24,6 +24,9 @@ stream_json_schema = {
                 "null",
             ]
         },
+        "data": {
+            "type": "object",
+        },
         "_submission_time": {"type": ["string", "null"]},
     },
 }


### PR DESCRIPTION
In preparation for our upgrade to Airbyte 0.50, our connectors need to have a known schema

Kobo Toolbox schemas aren't known in advance, so we're going to return the records inside an object having the keys

`{_id, data, _submission_time}`

where `data` contains the entire Kobo record. The field `_submission_time` is pulled out for incremental sync support