### PR TITLE
76 multiple base url for avni

### DIFF
--- a/airbyte-integrations/connectors/source-avni/Dockerfile
+++ b/airbyte-integrations/connectors/source-avni/Dockerfile
@@ -34,5 +34,5 @@ COPY source_avni ./source_avni
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-avni

--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5d297ac7-355e-4a04-be75-a5e7e175fc4e
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-avni
   githubIssueLabel: source-avni
   icon: avni.svg

--- a/airbyte-integrations/connectors/source-avni/source_avni/components.py
+++ b/airbyte-integrations/connectors/source-avni/source_avni/components.py
@@ -7,7 +7,6 @@ import requests
 @dataclass
 class CustomAuthenticator(BasicHttpAuthenticator):
 
-
     @property
     def token(self) -> str:
 
@@ -28,9 +27,9 @@ class CustomAuthenticator(BasicHttpAuthenticator):
         return "auth-token"
 
     def get_client_id(self):
-    
-        url_client = "https://app.avniproject.org/idp-details"
-        response = requests.get(url_client)
+
+        url_client = self.config["url_base"] + "/idp-details"
+        response = requests.get(url_client, timeout=30)
         response.raise_for_status()
         client = response.json()
         return client["cognito"]["clientId"]

--- a/airbyte-integrations/connectors/source-avni/source_avni/manifest.yaml
+++ b/airbyte-integrations/connectors/source-avni/source_avni/manifest.yaml
@@ -9,12 +9,13 @@ definitions:
 
   requester:
     type: HttpRequester
-    url_base: "https://app.avniproject.org/api"
+    url_base: "{{config['url_base']}}/api"
     http_method: "GET"
     authenticator:
       class_name: source_avni.components.CustomAuthenticator
       username: "{{config['username']}}"
       password: "{{config['password']}}"
+      idp_base: "{{config['url_base']}}"
 
   retriever:
     type: SimpleRetriever
@@ -123,6 +124,7 @@ spec:
     required:
       - username
       - password
+      - url_base
       - start_date
     additionalProperties: true
     properties:
@@ -135,6 +137,10 @@ spec:
         description: Your avni platform password
         title: Password
         airbyte_secret: true
+      url_base:
+        type: string
+        description: Your avni platform base url, with no trailing slash (/)
+        title: Base URL (no trailing /)
       start_date:
         type: string
         default: "2000-06-23T01:30:00.000Z"


### PR DESCRIPTION
## What
Added a "Base URL" field to the Avni connector setup form


## How
Added fields to the `manifest.yaml`
Referenced the `url_base` field in `CustomAuthenticator` to fetch the token from the correct IDP endpoint

## 🚨 User Impact 🚨
Existing source connectors need to be updated with their relevant Base URLs

