### PR TITLE
api key is actually username with api key

### DIFF
--- a/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
+++ b/airbyte-integrations/connectors/source-commcare/source_commcare/spec.yaml
@@ -11,9 +11,9 @@ connectionSpecification:
   properties:
     api_key:
       type: string
-      title: API Key
+      title: "Username:API Key"
       description: >-
-        Commcare API Key
+        Commcare username with API Key, colon-separated
       airbyte_secret: true
       order: 0
     project_space:


### PR DESCRIPTION
What we send to the API is actually the Commcare username + their API Key. This PR clarifies that in the form's label