### PR TITLE
check for cursor in state in case state is empty

### DIFF
--- a/airbyte-integrations/connectors/source-surveycto/source_surveycto/source.py
+++ b/airbyte-integrations/connectors/source-surveycto/source_surveycto/source.py
@@ -34,10 +34,12 @@ stream_json_schema = {
     },
 }
 
+
 class SurveyStream(HttpStream, ABC):
     transformer: TypeTransformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
     def __init__(self, config: Mapping[str, Any], form_id, schema, **kwargs):
+        self.form_id = None
         super().__init__()
 
         self.config = config
@@ -76,7 +78,8 @@ class SurveyctoStream(SurveyStream, IncrementalMixin):
 
     @state.setter
     def state(self, value: Mapping[str, Any]):
-        self._cursor_value = value[self.cursor_field]
+        if self.cursor_field in value:
+            self._cursor_value = value[self.cursor_field]
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## What
If the saved state is empty the connector complains that `SubmissionDate` isn't in `{}`


## How
Put a check within `SurveyctoStream.state`'s setter

## Review guide
Only `source.py` was changed

## User Impact
Now the connector will work correctly. I don't know why it worked earlier on fresh connections, perhaps one of our Airbyte upgrades broke this behavior


## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
